### PR TITLE
Recognize Containerfile

### DIFF
--- a/Syntaxes/Dockerfile.xml
+++ b/Syntaxes/Dockerfile.xml
@@ -9,6 +9,8 @@
 	<detectors>
 		<filename priority="1.0">Dockerfile</filename>
 		<filename priority="1.0">dockerfile</filename>
+		<filename priority="1.0">Containerfile</filename>
+		<filename priority="1.0">containerfile</filename>
 	</detectors>
 	
 	<comments>


### PR DESCRIPTION
The generic "Containerfile" is another name that uses the same syntax as Dockerfile. Thanks for making this syntax highlighting extension for Nova.