### PR TITLE
Sometimes Dockerfiles are prefixed for configuration reasons.

### DIFF
--- a/Syntaxes/Dockerfile.xml
+++ b/Syntaxes/Dockerfile.xml
@@ -11,6 +11,7 @@
 		<filename priority="1.0">dockerfile</filename>
 		<filename priority="1.0">Containerfile</filename>
 		<filename priority="1.0">containerfile</filename>
+		<extension priority="1.0">Dockerfile,dockerfile,Containerfile,containerfile</extension>
 	</detectors>
 	
 	<comments>


### PR DESCRIPTION
Sometimes a Dockerfile is prefixed for configuration reasons. This changes the them from a filename (current dectector) to an extension (which this adds).